### PR TITLE
drawingsテーブルのlabelカラムのNULLを許可した

### DIFF
--- a/db/migrate/20250823063419_create_drawings.rb
+++ b/db/migrate/20250823063419_create_drawings.rb
@@ -2,7 +2,7 @@ class CreateDrawings < ActiveRecord::Migration[8.0]
   def change
     create_table :drawings do |t|
       t.references :user, null: false, foreign_key: true
-      t.integer :label, null: false
+      t.integer :label, null: true
       t.timestamps
     end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -44,7 +44,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_06_060538) do
 
   create_table "drawings", force: :cascade do |t|
     t.bigint "user_id", null: false
-    t.integer "label", null: false
+    t.integer "label"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["label"], name: "index_drawings_on_label"


### PR DESCRIPTION
## 概要
drawingsテーブルのlabelカラムのNULLを許可し、ユーザーがラベルを指定していない場合でも推論をすることを可能にした。
